### PR TITLE
Add REST endpoints for Activity (create/edit/delete) #196

### DIFF
--- a/project/activities/serializers.py
+++ b/project/activities/serializers.py
@@ -4,4 +4,4 @@ from .models import Activity
 class ActivitySerializer(serializers.ModelSerializer):
     class Meta:
         model = Activity
-        fields = ["id", "activity_type", "activity_date", "note", "circle", "participants", "done"]
+        fields = '__all__'

--- a/project/activities/serializers.py
+++ b/project/activities/serializers.py
@@ -4,6 +4,7 @@ from .models import Activity
 
 class ActivitySerializer(serializers.ModelSerializer):
     """Serializer for the Activities"""
+
     class Meta:
         model = Activity
         fields = '__all__'

--- a/project/activities/serializers.py
+++ b/project/activities/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Activity
+
+class ActivitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Activity
+        fields = ["id", "activity_type", "activity_date", "note", "circle", "participants", "done"]

--- a/project/activities/serializers.py
+++ b/project/activities/serializers.py
@@ -1,7 +1,11 @@
 from rest_framework import serializers
 from .models import Activity
 
+
 class ActivitySerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Activities
+    """
     class Meta:
         model = Activity
         fields = '__all__'

--- a/project/activities/serializers.py
+++ b/project/activities/serializers.py
@@ -3,9 +3,7 @@ from .models import Activity
 
 
 class ActivitySerializer(serializers.ModelSerializer):
-    """
-    Serializer for the Activities
-    """
+    """Serializer for the Activities"""
     class Meta:
         model = Activity
         fields = '__all__'

--- a/project/activities/urls.py
+++ b/project/activities/urls.py
@@ -14,9 +14,9 @@ from activities import views
 
 urlpatterns = [
 
-    path('', views.activity_list),
-    
-    path('<int:id>', views.activity_details),
+    path("", views.activity_list, name="activity_list"),
+
+    path("<int:id>", views.activity_details, name="activity_details"),
 
     path(
         "create",

--- a/project/activities/urls.py
+++ b/project/activities/urls.py
@@ -15,13 +15,13 @@ from activities import views
 urlpatterns = [
 
     path(
-        "api", 
-        views.activity_list, 
+        "api",
+        views.activity_list,
         name="activity_list"
     ),
     path(
-        "api/<int:id>", 
-        views.activity_details, 
+        "api/<int:id>",
+        views.activity_details,
         name="activity_details"
     ),
     path(

--- a/project/activities/urls.py
+++ b/project/activities/urls.py
@@ -9,7 +9,15 @@ from .views import (
     ActivityUpdateView,
 )
 
+
+from activities import views
+
 urlpatterns = [
+
+    path('', views.activity_list),
+    
+    path('<int:id>', views.activity_details),
+
     path(
         "create",
         ActivityCreateView.as_view(),

--- a/project/activities/urls.py
+++ b/project/activities/urls.py
@@ -14,10 +14,16 @@ from activities import views
 
 urlpatterns = [
 
-    path("", views.activity_list, name="activity_list"),
-
-    path("<int:id>", views.activity_details, name="activity_details"),
-
+    path(
+        "api", 
+        views.activity_list, 
+        name="activity_list"
+    ),
+    path(
+        "api/<int:id>", 
+        views.activity_details, 
+        name="activity_details"
+    ),
     path(
         "create",
         ActivityCreateView.as_view(),

--- a/project/activities/views.py
+++ b/project/activities/views.py
@@ -17,7 +17,7 @@ from circles import views
 @api_view(['GET', 'POST'])
 def activity_list(request):
 
-    circle_id = Activity.objects.values_list("circle_id", flat=True)[4]
+    circle_id = Activity.objects.values_list("circle_id", flat=True).first()
     circle = Circle.objects.get(id=circle_id)
 
     if request.user in circle.companions:

--- a/project/activities/views.py
+++ b/project/activities/views.py
@@ -7,6 +7,56 @@ from django.views.generic import View
 
 from .forms import ActivityModelForm
 from .models import Activity
+from .serializers import ActivitySerializer
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+
+
+@api_view(['GET', 'POST'])
+def activity_list(request):
+
+    if request.method == 'GET':   
+        activities = Activity.objects.all()
+        serializer = ActivitySerializer(activities, many=True)
+        return Response(serializer.data)
+
+    if request.method == 'POST':
+        serializer = ActivitySerializer(data=request.data)
+        if serializer.is_valid():
+            serialiser.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+@api_view(['GET', 'PUT', 'DELETE'])
+def activity_details(request, id):
+
+    try:
+        activity = Activity.objects.get(pk=id)
+    except Activity.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = ActivitySerializer(activity)
+        return Response(serializer.data)
+
+    elif request.method == 'PUT':
+        serializer = ActivitySerializer(activity, data=request.data)
+        if serializer.is_valid():
+            serialiser.save()
+            return Response(serializer.data)        
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'DELETE':
+        activity.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+        
+        
+
+
+
+
+
+
 
 
 class ActivityCreateView(UserPassesTestMixin, LoginRequiredMixin, View):

--- a/project/activities/views.py
+++ b/project/activities/views.py
@@ -24,7 +24,7 @@ def activity_list(request):
     if request.method == 'POST':
         serializer = ActivitySerializer(data=request.data)
         if serializer.is_valid():
-            serialiser.save()
+            serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 @api_view(['GET', 'PUT', 'DELETE'])
@@ -42,7 +42,7 @@ def activity_details(request, id):
     elif request.method == 'PUT':
         serializer = ActivitySerializer(activity, data=request.data)
         if serializer.is_valid():
-            serialiser.save()
+            serializer.save()
             return Response(serializer.data)        
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -51,14 +51,6 @@ def activity_details(request, id):
         return Response(status=status.HTTP_204_NO_CONTENT)
         
         
-
-
-
-
-
-
-
-
 class ActivityCreateView(UserPassesTestMixin, LoginRequiredMixin, View):
     raise_exception = True
 

--- a/project/activities/views.py
+++ b/project/activities/views.py
@@ -8,35 +8,46 @@ from django.views.generic import View
 from .forms import ActivityModelForm
 from .models import Activity
 from .serializers import ActivitySerializer
+
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import status
-from circles.models import Circle
-from circles import views
+
 
 @api_view(['GET', 'POST'])
 def activity_list(request):
+    """
+    Circle member(s) can create a Circle Activity via a POST request
+    Circle members and coordinators can view all Circle Activities via a GET request    
+    """
 
     circle_id = Activity.objects.values_list("circle_id", flat=True).first()
     circle = Circle.objects.get(id=circle_id)
 
     if request.user in circle.companions:
 
-        if request.method == 'GET':   
+        if request.method == 'GET':
             activities = Activity.objects.all()
             serializer = ActivitySerializer(activities, many=True)
             return Response(serializer.data)
 
-        elif request.method == 'POST':
-                serializer = ActivitySerializer(data=request.data)
-                if serializer.is_valid():
-                    serializer.save()
-                    return Response(serializer.data, status=status.HTTP_201_CREATED)
+        if request.method == 'POST':
+            serializer = ActivitySerializer(data=request.data)
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     return Response(status=status.HTTP_403_FORBIDDEN)
 
+
 @api_view(['GET', 'PUT', 'DELETE'])
 def activity_details(request, id):
+    """
+    Circle member(s) can update a single Circle Activity via a PUT request
+    Circle coordinator(s) can delete a single Circle Activity via a DELETE request
+    Circle members and coordinators can view a single Circle Activity via a GET request
+    """
+
 
     try:
         activity = Activity.objects.get(pk=id)
@@ -52,20 +63,21 @@ def activity_details(request, id):
             serializer = ActivitySerializer(activity)
             return Response(serializer.data)
 
-        elif request.method == 'PUT':
-                serializer = ActivitySerializer(activity, data=request.data)
-                if serializer.is_valid():
-                    serializer.save()
-                    return Response(serializer.data)        
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        if request.method == 'PUT':
+            serializer = ActivitySerializer(activity, data=request.data)
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data)  
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        elif request.method == 'DELETE':
+        if request.method == 'DELETE':
             if request.user in circle.organizers:
                 activity.delete()
                 return Response(status=status.HTTP_204_NO_CONTENT)
             return Response(status=status.HTTP_403_FORBIDDEN)
-            
+
     return Response(status=status.HTTP_403_FORBIDDEN)
+
         
 class ActivityCreateView(UserPassesTestMixin, LoginRequiredMixin, View):
     raise_exception = True

--- a/project/activities/views.py
+++ b/project/activities/views.py
@@ -18,9 +18,8 @@ from rest_framework import status
 def activity_list(request):
     """
     Circle member(s) can create a Circle Activity via a POST request
-    Circle members and coordinators can view all Circle Activities via a GET request    
+    Circle members and coordinators can view all Circle Activities via a GET request
     """
-
     circle_id = Activity.objects.values_list("circle_id", flat=True).first()
     circle = Circle.objects.get(id=circle_id)
 
@@ -47,8 +46,6 @@ def activity_details(request, id):
     Circle coordinator(s) can delete a single Circle Activity via a DELETE request
     Circle members and coordinators can view a single Circle Activity via a GET request
     """
-
-
     try:
         activity = Activity.objects.get(pk=id)
     except Activity.DoesNotExist:
@@ -67,7 +64,7 @@ def activity_details(request, id):
             serializer = ActivitySerializer(activity, data=request.data)
             if serializer.is_valid():
                 serializer.save()
-                return Response(serializer.data)  
+                return Response(serializer.data)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         if request.method == 'DELETE':
@@ -78,7 +75,7 @@ def activity_details(request, id):
 
     return Response(status=status.HTTP_403_FORBIDDEN)
 
-        
+
 class ActivityCreateView(UserPassesTestMixin, LoginRequiredMixin, View):
     raise_exception = True
 

--- a/project/core/settings.py
+++ b/project/core/settings.py
@@ -178,6 +178,7 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.TokenAuthentication",
+        'rest_framework.authentication.SessionAuthentication',
         # 'dj_rest_auth.jwt_auth.JWTCookieAuthentication'
     ),
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("circles/", include("circles.urls")),
     path("__reload__/", include("django_browser_reload.urls")),
-    path("api-auth/", include("rest_framework.urls", namespace = "rest_framework")),
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
 ] + media_urlpatterns
 
 handler404 = "error_handling.views.handler404"

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("circles/", include("circles.urls")),
     path("__reload__/", include("django_browser_reload.urls")),
+    path("api-auth/", include("rest_framework.urls", namespace = "rest_framework")),
 ] + media_urlpatterns
 
 handler404 = "error_handling.views.handler404"


### PR DESCRIPTION
This is a solution for #196

I have created two api endpoints: activities/api for retrieving all activities and the activities/api/<id> for the individual activities 
  
The requested CRUD functionality is added as well as the permissions for companions and organizers.
  
I am not entirely sure about line 20 in activities/views.py. Please have a look whether this is a good solution to select the circle_id in order to check if the user is part of the circle.
  
And any other feed back to improve this solution is highly appreciated.

Thanks